### PR TITLE
Proposal: Include "livewire" in SEO critical areas

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -32,9 +32,9 @@ class AppServiceProvider extends ServiceProvider
             ->site(config('app.name'))
             ->title(
                 modify: fn (string $title) => $title . ' - ' . config('app.name'),
-                default: 'Filament - The elegant TALLkit for Laravel artisans.',
+                default: 'Filament - Livewire Laravel Admin Panel',
             )
-            ->description(default: 'Filament is a collection of tools for rapidly building beautiful TALL stack interfaces, designed for humans.')
+            ->description(default: 'Filament is an open source Laravel admin panel, table builder and form builder. Built using the TALL stack - Livewire, Alpine & Tailwind CSS.')
             ->twitterSite('filamentphp');
 
         Model::preventLazyLoading();

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -7,11 +7,11 @@
         <div class="space-y-12 max-w-screen-sm">
             <div class="space-y-4">
                 <h1 class="font-heading font-bold text-gray-900 text-4xl leading-tight md:text-5xl md:leading-tight lg:text-6xl lg:leading-tight">
-                    The elegant <span class="text-primary-500">TALL</span>kit for Laravel artisans.
+                    The elegant Laravel <strong class="font-bold text-primary-500">Livewire</strong> admin panel.
                 </h1>
 
                 <h3 class="text-gray-700 text-2xl">
-                    Filament is a collection of tools for rapidly building beautiful TALL stack interfaces, designed for humans.
+                    Filament is an admin panel for creating beautiful, customizable interfaces using the TALL stack &mdash; Tailwind, Alpine, Livewire and Laravel.
                 </h3>
             </div>
 


### PR DESCRIPTION
I'm suggesting that adding mentions of "laravel livewire admin panel" will get the site a bit more search exposure. I've been careful to not remove mentions of TALLstack because that will also be searched for, I don't think Google's algo has figured that "tall stack" and "livewire" are near synonyms.

There's loads of other stuff that can be done, but I don't want to interfere too much.