### PR TITLE
feature: add action to publish plugins

### DIFF
--- a/app/Actions/PublishPlugin.php
+++ b/app/Actions/PublishPlugin.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Actions;
+
+use App\Enums\PluginStatus;
+use App\Models\Plugin;
+
+class PublishPlugin
+{
+    public function __invoke(Plugin $plugin): void
+    {
+        $plugin->update([
+            'status' => PluginStatus::PUBLISHED,
+        ]);
+    }
+}

--- a/app/Filament/Resources/PluginResource.php
+++ b/app/Filament/Resources/PluginResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources;
 
+use App\Actions\PublishPlugin;
 use App\Enums\PluginCategory;
 use App\Enums\PluginLicense;
 use App\Enums\PluginStatus;
@@ -12,6 +13,7 @@ use App\Filament\Resources\PluginResource\Widgets\PluginStatusSwitcher;
 use App\Models\Plugin;
 use Closure;
 use Filament\Forms;
+use Filament\Tables\Actions\ButtonAction;
 use Filament\Pages\Page;
 use Filament\Resources\Form;
 use Filament\Resources\Resource;
@@ -160,6 +162,12 @@ class PluginResource extends Resource
                 Tables\Columns\TextColumn::make('author.name')
                     ->searchable()
                     ->visible(auth()->user()->is_admin),
+            ])
+            ->prependActions([
+                ButtonAction::make('publish')
+                    ->requiresConfirmation()
+                    ->visible(fn (Plugin $record) => $record->status === PluginStatus::PENDING)
+                    ->action(fn (Plugin $record, PublishPlugin $publishPluginAction) => $publishPluginAction($record))
             ])
             ->filters([
                 Tables\Filters\SelectFilter::make('status')->options(collect(PluginStatus::cases())->mapWithKeys(fn (PluginStatus $status): array => [$status->value => $status->getLabel()])),

--- a/app/Filament/Resources/PluginResource.php
+++ b/app/Filament/Resources/PluginResource.php
@@ -13,7 +13,6 @@ use App\Filament\Resources\PluginResource\Widgets\PluginStatusSwitcher;
 use App\Models\Plugin;
 use Closure;
 use Filament\Forms;
-use Filament\Tables\Actions\ButtonAction;
 use Filament\Pages\Page;
 use Filament\Resources\Form;
 use Filament\Resources\Resource;
@@ -162,12 +161,6 @@ class PluginResource extends Resource
                 Tables\Columns\TextColumn::make('author.name')
                     ->searchable()
                     ->visible(auth()->user()->is_admin),
-            ])
-            ->prependActions([
-                ButtonAction::make('publish')
-                    ->requiresConfirmation()
-                    ->visible(fn (Plugin $record) => $record->status === PluginStatus::PENDING)
-                    ->action(fn (Plugin $record, PublishPlugin $publishPluginAction) => $publishPluginAction($record))
             ])
             ->filters([
                 Tables\Filters\SelectFilter::make('status')->options(collect(PluginStatus::cases())->mapWithKeys(fn (PluginStatus $status): array => [$status->value => $status->getLabel()])),

--- a/app/Filament/Resources/PluginResource/Pages/EditPlugin.php
+++ b/app/Filament/Resources/PluginResource/Pages/EditPlugin.php
@@ -2,11 +2,13 @@
 
 namespace App\Filament\Resources\PluginResource\Pages;
 
+use App\Models\Plugin;
 use App\Enums\PluginStatus;
-use App\Filament\Resources\PluginResource;
+use App\Actions\PublishPlugin;
 use Filament\Pages\Actions\Action;
 use Filament\Pages\Actions\ButtonAction;
 use Filament\Resources\Pages\EditRecord;
+use App\Filament\Resources\PluginResource;
 
 class EditPlugin extends EditRecord
 {
@@ -91,6 +93,10 @@ class EditPlugin extends EditRecord
     {
         return array_merge([
             $this->getViewAction(),
+            ButtonAction::make('publish')
+                ->requiresConfirmation()
+                ->visible(fn () => $this->record->status === PluginStatus::PENDING && auth()->user()->is_admin)
+                ->action(fn (PublishPlugin $publishPluginAction) => $publishPluginAction($this->record))
         ], parent::getActions());
     }
 


### PR DESCRIPTION
First step to abstracting out the logic for publishing plugins.

Once this has been merged in, we can add some stuff to the action to send emails, do Discord bits as well.