### PR TITLE
Add doc search to every page

### DIFF
--- a/resources/views/components/layouts/base.blade.php
+++ b/resources/views/components/layouts/base.blade.php
@@ -2,7 +2,7 @@
     'darkMode' => false,
     'previewify' => null,
     'previewifyData' => [],
-    'docSearch' => true
+    'docSearch' => true,
 ])
 
 <!DOCTYPE html>

--- a/resources/views/components/layouts/base.blade.php
+++ b/resources/views/components/layouts/base.blade.php
@@ -2,6 +2,7 @@
     'darkMode' => false,
     'previewify' => null,
     'previewifyData' => [],
+    'docSearch' => true
 ])
 
 <!DOCTYPE html>
@@ -46,6 +47,10 @@
         'antialiased font-sans text-gray-900',
         'dark:text-white dark:bg-gray-900' => $darkMode,
     ])>
+        @if($docSearch)
+            <div id="docsearch" class="hidden"></div>
+        @endif
+
         {{ $slot }}
     </body>
 </html>

--- a/resources/views/components/layouts/base.blade.php
+++ b/resources/views/components/layouts/base.blade.php
@@ -47,7 +47,7 @@
         'antialiased font-sans text-gray-900',
         'dark:text-white dark:bg-gray-900' => $darkMode,
     ])>
-        @if($docSearch)
+        @if ($docSearch)
             <div id="docsearch" class="hidden"></div>
         @endif
 

--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -3,7 +3,7 @@
     'title' => $page->title,
     'subtitle' => $package->description,
     'repository' => $package->package,
-]" dark-mode>
+]" dark-mode :doc-search="false">
     <x-nav dark-mode />
 
     <div x-data="{}" class="space-y-12">


### PR DESCRIPTION
Quite often I just visit the Filament website to check something small in the docs. Every time it irritates me that the shortcut for the doc search isn't available on the homepage or any other page, but only on the docs page.

This PR adds an invisible element with `id="docsearch"` to every page, so that you can immediately start searching on the homepage. This is the same as how Tailwind CSS, Laravel and Livewire have their website.

I only tested this on the homepage, since I missed a test db and things like a license key for Spatie's comments. However, I'm pretty sure that it works.

Thanks!