### PR TITLE
Randomly select most famous item from top row of most popular

### DIFF
--- a/app/Http/Controllers/Blog/ListArticlesController.php
+++ b/app/Http/Controllers/Blog/ListArticlesController.php
@@ -16,7 +16,9 @@ class ListArticlesController extends Controller
                 ->published()
                 ->with(['author'])
                 ->orderByDesc('views')
-                ->first(),
+                ->limit(3)
+                ->get()
+                ->random(),
             'latestArticle' => Article::query()
                 ->published()
                 ->with(['author'])

--- a/app/Http/Controllers/Blog/ListArticlesController.php
+++ b/app/Http/Controllers/Blog/ListArticlesController.php
@@ -16,7 +16,7 @@ class ListArticlesController extends Controller
                 ->published()
                 ->with(['author'])
                 ->orderByDesc('views')
-                ->limit(3)
+                ->limit(5)
                 ->get()
                 ->random(),
             'latestArticle' => Article::query()

--- a/app/Http/Controllers/Links/ListLinksController.php
+++ b/app/Http/Controllers/Links/ListLinksController.php
@@ -17,7 +17,9 @@ class ListLinksController extends Controller
                 ->published()
                 ->with(['author', 'media'])
                 ->orderByDesc('views')
-                ->first(),
+                ->limit(4)
+                ->get()
+                ->random(),
             'latestLink' => Link::query()
                 ->published()
                 ->with(['author', 'media'])

--- a/app/Http/Controllers/Links/ListLinksController.php
+++ b/app/Http/Controllers/Links/ListLinksController.php
@@ -17,7 +17,7 @@ class ListLinksController extends Controller
                 ->published()
                 ->with(['author', 'media'])
                 ->orderByDesc('views')
-                ->limit(4)
+                ->limit(5)
                 ->get()
                 ->random(),
             'latestLink' => Link::query()

--- a/app/Http/Controllers/Plugins/ListPluginsController.php
+++ b/app/Http/Controllers/Plugins/ListPluginsController.php
@@ -18,7 +18,9 @@ class ListPluginsController extends Controller
                 ->published()
                 ->with(['author', 'media'])
                 ->orderByDesc('views')
-                ->first(),
+                ->limit(4)
+                ->get()
+                ->random(),
             'featuredPlugins' => Plugin::query()
                 ->published()
                 ->with(['author', 'media'])

--- a/app/Http/Controllers/Plugins/ListPluginsController.php
+++ b/app/Http/Controllers/Plugins/ListPluginsController.php
@@ -18,7 +18,7 @@ class ListPluginsController extends Controller
                 ->published()
                 ->with(['author', 'media'])
                 ->orderByDesc('views')
-                ->limit(4)
+                ->limit(5)
                 ->get()
                 ->random(),
             'featuredPlugins' => Plugin::query()

--- a/app/Http/Controllers/Tricks/ListTricksController.php
+++ b/app/Http/Controllers/Tricks/ListTricksController.php
@@ -16,7 +16,9 @@ class ListTricksController extends Controller
                 ->published()
                 ->with(['author'])
                 ->orderByDesc('favorites')
-                ->first(),
+                ->limit(3)
+                ->get()
+                ->random(),
             'latestTrick' => Trick::query()
                 ->published()
                 ->with(['author'])

--- a/app/Http/Controllers/Tricks/ListTricksController.php
+++ b/app/Http/Controllers/Tricks/ListTricksController.php
@@ -16,7 +16,7 @@ class ListTricksController extends Controller
                 ->published()
                 ->with(['author'])
                 ->orderByDesc('favorites')
-                ->limit(3)
+                ->limit(5)
                 ->get()
                 ->random(),
             'latestTrick' => Trick::query()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1066486/193471317-245b5aa2-2f7f-4a56-99d7-795c07274404.png)

This PR will get the top row of most popular plugins/tricks/articles/links and randomly select one to showcase at the top.

It gives other creators a bigger chance to be featured/seen as well. These spots have been pretty static for the last couple of weeks/months, from what I've seen.

*Note that the blog does not currently have these highlights at the top, but I made the change there anyway.*

I could not test this locally within the app (because of missing license for Spatie Comments), but I tried the queries in Tinker and everything seemed to be in order.