### PR TITLE
Add `sm:` breakpoint to highlighted items

### DIFF
--- a/resources/views/blog/list-articles.blade.php
+++ b/resources/views/blog/list-articles.blade.php
@@ -29,7 +29,7 @@
     </x-header>
 
     <x-section>
-{{--        <div class="grid grid-cols-1 gap-8 lg:grid-cols-3">--}}
+{{--        <div class="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">--}}
 {{--            <div class="space-y-2">--}}
 {{--                <h2 class="text-lg font-heading text-gray-900">--}}
 {{--                    ⭐️ Famous article--}}

--- a/resources/views/links/list-links.blade.php
+++ b/resources/views/links/list-links.blade.php
@@ -29,7 +29,7 @@
     </x-header>
 
     <x-section>
-        <div class="grid grid-cols-1 gap-8 lg:grid-cols-3">
+        <div class="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
             <div class="space-y-2">
                 <h2 class="text-lg font-heading text-gray-900">
                     ⭐️ Famous link

--- a/resources/views/plugins/list-plugins.blade.php
+++ b/resources/views/plugins/list-plugins.blade.php
@@ -29,7 +29,7 @@
     </x-header>
 
     <x-section>
-        <div class="grid grid-cols-1 gap-8 lg:grid-cols-3">
+        <div class="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
             <div class="space-y-2">
                 <h2 class="text-lg font-heading text-gray-900">
                     ⭐️ Famous plugin

--- a/resources/views/tricks/list-tricks.blade.php
+++ b/resources/views/tricks/list-tricks.blade.php
@@ -29,7 +29,7 @@
     </x-header>
 
     <x-section>
-        <div class="grid grid-cols-1 gap-8 lg:grid-cols-3">
+        <div class="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
             <div class="space-y-2">
                 <h2 class="text-lg font-heading text-gray-900">
                     ⭐️ Famous trick


### PR DESCRIPTION
On medium sized screens the highlighted items are huge.

This change adds a `sm:` breakpoint to make them less huge on **Plugins**, **Tricks**, **Blog** and **Links** pages. Bummer that it's not an even number, but still works better in my opinion.

*Screen width on screenshots are 1022 px. Right below `lg:` breakpoint (1024px)*

## Before
![2022-10-02_23-03-31](https://user-images.githubusercontent.com/1066486/193476357-db137e9d-4e0b-46e8-8b0a-403e3ce18b33.png)

## After
![2022-10-02_23-05-15](https://user-images.githubusercontent.com/1066486/193476360-7799ddbf-1d18-415c-8ae0-2af5cb4b38ba.png)
