### PR TITLE
fix: Position h5 and h6 title anchors

### DIFF
--- a/docs/src/styles/tailwind.css
+++ b/docs/src/styles/tailwind.css
@@ -26,7 +26,9 @@
 
     .prose h2,
     .prose h3,
-    .prose h4 {
+    .prose h4,
+    .prose h5,
+    .prose h6 {
         @apply lg:relative;
     }
 


### PR DESCRIPTION
I noticed I omitted the `h5` and `h6` in https://github.com/filamentphp/filamentphp.com/pull/47

Here's an example of the issue :

![anchor](https://github.com/filamentphp/filamentphp.com/assets/7805679/9d052d04-f035-4933-92ea-41c4920a3964)
