### PR TITLE
fix: update default dashboard route in example

### DIFF
--- a/docs/src/pages/3.x/panels/navigation.mdx
+++ b/docs/src/pages/3.x/panels/navigation.mdx
@@ -259,8 +259,8 @@ public function panel(Panel $panel): Panel
             return $builder->items([
                 NavigationItem::make('Dashboard')
                     ->icon('heroicon-o-home')
-                    ->isActiveWhen(fn (): bool => request()->routeIs('filament.pages.dashboard'))
-                    ->url(route('filament.pages.dashboard')),
+                    ->isActiveWhen(fn (): bool => request()->routeIs('filament.admin.pages.dashboard'))
+                    ->url(route('filament.admin.pages.dashboard')),
                 ...UserResource::getNavigationItems(),
                 ...Settings::getNavigationItems(),
             ]);


### PR DESCRIPTION
When following the documentation to create a navigation link to the dashboard, an error was thrown due to a missing route. V3 has changed the route from `filament.pages.dashboard` to `filament.admin.pages.dashboard` for the default dashboard page generated from a fresh install. This updates the documentation accordingly.