### PR TITLE
Fixed return type in getNavigationLabel() example in docs

### DIFF
--- a/docs/src/pages/3.x/panels/navigation.mdx
+++ b/docs/src/pages/3.x/panels/navigation.mdx
@@ -19,7 +19,7 @@ protected static ?string $navigationLabel = 'Custom Navigation Label';
 Alternatively, you may override the `getNavigationLabel()` method:
 
 ```php
-public static function getNavigationLabel(): ?string
+public static function getNavigationLabel(): string
 {
     return 'Custom Navigation Label';
 }


### PR DESCRIPTION
In the example for getNavigationLabel, the return type was set to ?string, but string is required by the abstract class. 

If you use the existing code, you get "Return type declaration must be compatible with Resource::getNavigationLabel() : string"

This is the method it refers to:
https://github.com/filamentphp/filament/blob/9a31e5e7841f73befffab7284228364c75f4b3d6/packages/panels/src/Resources/Resource.php#L715