### PR TITLE
Fix docs responsive header wrapping

### DIFF
--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -15,7 +15,7 @@ let { navigation = null } = Astro.props
     class="sticky top-0 z-50 px-4 py-3 border-b border-b-fair-pink dark:border-b-slate-800 transition duration-500 sm:px-6 lg:px-8 bg-cream dark:bg-[#171527]"
 >
     <div
-        class="w-full max-w-8xl mx-auto flex flex-wrap gap-5 items-center justify-between"
+        class="w-full max-w-8xl mx-auto flex flex-wrap gap-5 items-center justify-between sm:flex-nowrap"
     >
         <div class="relative flex flex-grow basis-0 items-center gap-3">
             <div class="flex lg:hidden">

--- a/docs/src/components/VersionSelector.astro
+++ b/docs/src/components/VersionSelector.astro
@@ -20,7 +20,7 @@ let currentVersion = segments[1].replaceAll("/", "");
         class="flex h-9 items-center justify-center whitespace-nowrap rounded-full px-3 text-sm text-gray-600 ring-1 ring-merino dark:bg-dolphin/10 dark:text-gray-300 dark:ring-inset dark:ring-white/5"
         aria-label="Open version options"
     >
-      <span>Version&nbsp;</span>
+      <span class="hidden sm:block">Version&nbsp;</span>
       <span id="current-version" class="font-bold">{currentVersion}</span>
     </button>
 


### PR DESCRIPTION
Fix header wrapping on small mobile screens. Affected my small iPhone SE 2nd edition.
<img width="805" alt="Screenshot 2023-08-07 at 18 12 46" src="https://github.com/filamentphp/filamentphp.com/assets/533658/7f2c0bc3-d3c3-489d-bf2e-fe524dc9c19e">

Hide the version text. 
<img width="794" alt="Screenshot 2023-08-07 at 18 12 12" src="https://github.com/filamentphp/filamentphp.com/assets/533658/4f55ce74-205c-406e-aaf8-14960cd61bc5">

 
Also disabled wrapping on medium size screen to prevent this. NOTE need to rebuild resources new class used `sm:flex-nowrap`
<img width="923" alt="Screenshot 2023-08-07 at 18 11 59" src="https://github.com/filamentphp/filamentphp.com/assets/533658/b427a9cf-6a2b-4cc3-af82-585dc88dd4a8">
