### PR TITLE
Docs: additional storage details

### DIFF
--- a/docs/src/pages/3.x/forms/fields/file-upload.mdx
+++ b/docs/src/pages/3.x/forms/fields/file-upload.mdx
@@ -21,7 +21,7 @@ FileUpload::make('attachment')
 
 ## Configuring the storage disk and directory
 
-By default, files will be uploaded publicly to your storage disk defined in the [configuration file](../installation#publishing-configuration). You can also set the `FILAMENT_FILESYSTEM_DISK` environment variable to change this.
+By default, files will be uploaded publicly to your storage disk defined in the [configuration file](../installation#publishing-configuration). Be sure to link your storage directory with `php artisan storage:link` in order to serve the files stored in that directory. You can also set the `FILAMENT_FILESYSTEM_DISK` environment variable to change this.
 
 > To correctly preview images and other files, FilePond requires files to be served from the same domain as the app, or the appropriate CORS headers need to be present. Ensure that the `APP_URL` environment variable is correct, or modify the [filesystem](https://laravel.com/docs/filesystem) driver to set the correct URL. If you're hosting files on a separate domain like S3, ensure that CORS headers are set up.
 


### PR DESCRIPTION
Added: additional line to remind users to create a storage link to serve files from their public directory

Should help reduce any bug reports about the storage folder not being linked properly. The errors you see on the page when this has not happened are just 404 ones and aren't the most helpful.