### PR TITLE
change minisearch fuzzy search from 0.1 to true

### DIFF
--- a/resources/views/components/plugins/list.blade.php
+++ b/resources/views/components/plugins/list.blade.php
@@ -8,7 +8,7 @@
             searchEngine = new MiniSearch({
                 fields: ['name', 'description', 'github_repository', 'author.name'],
                 searchOptions: {
-                    fuzzy: 0.1,
+                    fuzzy: true,
                     prefix: true,
                 },
                 extractField: (document, fieldName) => {


### PR DESCRIPTION
When you pass `true` for the fuzzy option the MiniSearch will set some default parameters for fuzzy search.
When you pass `0.1` as the fuzzy option the MiniSearch will match in a maximum edit distance of 10%. it means in a 10-character term you can have 1 misplaced character.

The default option performs much better in this scenario.

For example in the term `look` the current options return 0 results while these new options return 2 results including the plugins that have `lock` in their name.