### PR TITLE
[Plugin] Job Monitor now support v3

### DIFF
--- a/content/plugins/croustibat-jobs-monitor.md
+++ b/content/plugins/croustibat-jobs-monitor.md
@@ -4,12 +4,11 @@ slug: croustibat-jobs-monitor
 author_slug: croustibat
 categories: [developer-tools, panel-builder]
 description: Monitor your queues from a panel
-discord_url: https://discord.com/channels/883083792112300104/1113032991845912646
 docs_url: https://raw.githubusercontent.com/croustibat/filament-jobs-monitor/main/README.md
 github_repository: croustibat/filament-jobs-monitor
 has_dark_theme: true
 has_translations: true
 image: croustibat-jobs-monitor.jpg
-versions: [2]
+versions: [2, 3]
 publish_date: 2023-05-30
 ---

--- a/content/plugins/croustibat-jobs-monitor.md
+++ b/content/plugins/croustibat-jobs-monitor.md
@@ -4,6 +4,7 @@ slug: croustibat-jobs-monitor
 author_slug: croustibat
 categories: [developer-tools, panel-builder]
 description: Monitor your queues from a panel
+discord_url: https://discord.com/channels/883083792112300104/1113032991845912646
 docs_url: https://raw.githubusercontent.com/croustibat/filament-jobs-monitor/main/README.md
 github_repository: croustibat/filament-jobs-monitor
 has_dark_theme: true


### PR DESCRIPTION
Job monitor now support FIlament V3.
Just updated the version array. 