### PR TITLE
Reset page number on filter changes

### DIFF
--- a/resources/views/components/plugins/list.blade.php
+++ b/resources/views/components/plugins/list.blade.php
@@ -4,8 +4,9 @@
     x-ref="section"
     x-init="
         () => {
-            // Reset the page number on search input change
-            $watch('search', (newValue, oldValue) => {
+            // Reset the page number when we do things that change the amount of results
+            // This handles search as well as applying other filters like categories
+            $watch('totalItems', (newValue, oldValue) => {
                 if (newValue !== oldValue) {
                     currentPage = 1
                 }


### PR DESCRIPTION
Watching totalItems variable instead of search so we can check for changes to the total amount of plugins.

This should handle all filters including search

Fixes #307

I'm not an Alpine/JS dev so I may have not understood a potential issue like totalItems resets between requests or something.
