### PR TITLE
Smoother search animation by adding debounce to search input.

### DIFF
--- a/resources/views/components/articles/list.blade.php
+++ b/resources/views/components/articles/list.blade.php
@@ -300,7 +300,7 @@
                 {{-- Search Input --}}
                 <input
                     type="text"
-                    x-model="search"
+                    x-model.debounce.500ms="search"
                     placeholder="Search ..."
                     class="w-full appearance-none border-none bg-transparent py-3 pl-12 pr-10 text-sm outline-none placeholder:transition placeholder:duration-200 focus:ring-0 group-focus-within/search-bar:placeholder:translate-x-1 group-focus-within/search-bar:placeholder:opacity-0"
                 />

--- a/resources/views/components/plugins/list.blade.php
+++ b/resources/views/components/plugins/list.blade.php
@@ -273,7 +273,7 @@
                 {{-- Search Input --}}
                 <input
                     type="text"
-                    x-model="search"
+                    x-model.debounce.500ms="search"
                     placeholder="Search ..."
                     class="w-full appearance-none border-none bg-transparent py-3 pl-12 pr-10 text-sm outline-none placeholder:transition placeholder:duration-200 focus:ring-0 group-focus-within/search-bar:placeholder:translate-x-1 group-focus-within/search-bar:placeholder:opacity-0"
                 />


### PR DESCRIPTION
I've added 500ms debounce modifier to the search input in both articles and plugins search pages to give room to the animation to play smoothly.