### PR TITLE
Update community wording to 'Content'

### DIFF
--- a/resources/views/components/articles/hero.blade.php
+++ b/resources/views/components/articles/hero.blade.php
@@ -83,7 +83,7 @@
                     class="text-5xl font-black"
                     x-ref="plugins"
                 >
-                    Community
+                    Content
                 </div>
 
                 {{-- Star --}}

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -114,7 +114,7 @@
                         href="{{ route('articles') }}"
                         class="p-2 transition duration-300 will-change-transform hover:translate-x-1 hover:text-black motion-reduce:transition-none motion-reduce:hover:transform-none"
                     >
-                        Community
+                        Content
                     </a>
                     <a
                         href="{{ route('consulting') }}"

--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -128,7 +128,7 @@
                 'font-bold' => request()->routeIs('articles*'),
             ])
         >
-            <div class="gsap-fadein">Community</div>
+            <div class="gsap-fadein">Content</div>
 
             @if (request()->routeIs('articles*'))
                 <div

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers;
+use App\Models\Article;
 use App\Models\Plugin;
 use App\Models\Star;
 use Illuminate\Http\RedirectResponse;
@@ -125,6 +126,20 @@ Route::prefix('/docs')->group(function () {
 });
 
 Route::prefix('/community')->group(function () {
+    Route::get('/', function () {
+        return redirect(status: 301)->route('articles');
+    });
+
+    Route::name('articles.')->group(function () {
+        Route::prefix('/{article:slug}')->group(function () {
+            Route::get('/', function (Article $article) {
+                return redirect(status: 301)->route('articles.view', ['article' => $article->slug]);
+            });
+        });
+    });
+});
+
+Route::prefix('/content')->group(function () {
     Route::get('/', Controllers\Articles\ListArticlesController::class)->name('articles');
 
     Route::name('articles.')->group(function () {


### PR DESCRIPTION
## Summary

As part of our work to bring content generation and sourcing in-house, here is a small change to the website that removes the "Community" wording for our content pages and introduces "Content" instead.

I'm open to changing the wording, but I wanted to get the conversation going about how we wanted to handle this on our website.

This PR also adds the necessary 301 redirects to move all of our existing content from `/community` to `/content`.

Thoughts?