### PR TITLE
Fix incorrect "articles" mobile nav item

### DIFF
--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -129,7 +129,7 @@
                             'group-hover/sidebar-link:translate-x-1' => ! request()->routeIs('articles*'),
                         ])
                     >
-                        Community
+                        Content
                     </div>
                 </a>
             </li>


### PR DESCRIPTION
The mobile nav item for our content was not changed over from "Community" to "Content". This fixes that.