### PR TITLE
feat: convert relative image urls to absolute

### DIFF
--- a/app/Support/Markdown.php
+++ b/app/Support/Markdown.php
@@ -2,6 +2,7 @@
 
 namespace App\Support;
 
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\HtmlString;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
@@ -9,15 +10,16 @@ use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension;
 use League\CommonMark\Extension\Table\TableExtension;
 use League\CommonMark\Extension\TableOfContents\TableOfContentsExtension;
 use League\CommonMark\MarkdownConverter;
+use Stringable;
 use Torchlight\Commonmark\V2\TorchlightExtension;
 
-class Markdown
+class Markdown implements Htmlable, Stringable
 {
-    public static function parse(string $text): HtmlString
-    {
-        $text = self::convertSpecialBlockQuotes($text);
+    protected Environment $environment;
 
-        $environment = new Environment([
+    public function __construct(protected string $content)
+    {
+        $this->environment = new Environment([
             'allow_unsafe_links' => false,
             'heading_permalink' => [
                 'html_class' => 'heading-anchor',
@@ -37,35 +39,85 @@ class Markdown
             ],
         ]);
 
-        $environment->addExtension(new CommonMarkCoreExtension);
-        $environment->addExtension(new TableExtension);
-        $environment->addExtension(new HeadingPermalinkExtension);
-        $environment->addExtension(new TorchlightExtension);
-        $environment->addExtension(new TableOfContentsExtension);
-
-        $converter = new MarkdownConverter($environment);
-
-        return new HtmlString($converter->convert($text)->getContent());
+        $this->environment->addExtension(new CommonMarkCoreExtension);
+        $this->environment->addExtension(new TableExtension);
+        $this->environment->addExtension(new HeadingPermalinkExtension);
+        $this->environment->addExtension(new TorchlightExtension);
+        $this->environment->addExtension(new TableOfContentsExtension);
     }
 
-    protected static function convertSpecialBlockQuotes(string $text): string
+    public static function parse(string $text): static
     {
-        $searchPatterns = [
-            '/> \[\!NOTE\]\s*\n> /',
-            '/> \[\!TIP\]\s*\n> /',
-            '/> \[\!IMPORTANT\]\s*\n> /',
-            '/> \[\!WARNING\]\s*\n> /',
-            '/> \[\!CAUTION\]\s*\n> /',
-        ];
-        $replacePatterns = [
-            '> 📝 **Note:** ',
-            '> 💡 **Tip:** ',
-            '> ❗ **Important:** ',
-            '> ⚠️ **Warning:** ',
-            '> ⚠️ **Caution:** ',
-        ];
+        $static = app(static::class, ['content' => $text]);
 
-        // Perform the replacement
-        return preg_replace($searchPatterns, $replacePatterns, $text);
+        $static->convert();
+        $static->removeH1Tags();
+        $static->convertSpecialBlockQuotes();
+
+        return $static;
+    }
+
+    protected function convert(): static
+    {
+        $this->content = (new MarkdownConverter($this->environment))
+            ->convert($this->content)
+            ->getContent();
+
+        return $this;
+    }
+
+    protected function removeH1Tags(): static
+    {
+        $this->content = preg_replace(
+            pattern: '/\<h1(.*)\>(.*)\<\/h1\>/',
+            replacement: '',
+            subject: $this->content
+        );
+
+        return $this;
+    }
+
+    protected function convertSpecialBlockQuotes(): static
+    {
+        $this->content = preg_replace(
+            pattern: [
+                '/> \[\!NOTE\]\s*\n> /',
+                '/> \[\!TIP\]\s*\n> /',
+                '/> \[\!IMPORTANT\]\s*\n> /',
+                '/> \[\!WARNING\]\s*\n> /',
+                '/> \[\!CAUTION\]\s*\n> /',
+            ],
+            replacement: [
+                '> 📝 **Note:** ',
+                '> 💡 **Tip:** ',
+                '> ❗ **Important:** ',
+                '> ⚠️ **Warning:** ',
+                '> ⚠️ **Caution:** ',
+            ],
+            subject: $this->content
+        );
+
+        return $this;
+    }
+
+    public function absoluteImageUrls(string $baseUrl): static
+    {
+        $this->content = preg_replace(
+            pattern: '/src=["\'](?!https?:\/\/)([^"\']+)["\'][^>]/i',
+            replacement: 'src="' . $baseUrl . '$1" ',
+            subject: $this->content
+        );
+
+        return $this;
+    }
+
+    public function __toString(): string
+    {
+        return str($this->content)->sanitizeHtml();
+    }
+
+    public function toHtml()
+    {
+        return new HtmlString($this->content);
     }
 }

--- a/resources/views/articles/view-article.blade.php
+++ b/resources/views/articles/view-article.blade.php
@@ -160,7 +160,7 @@
                     <div
                         class="prose selection:bg-stone-500/30 prose-a:break-words prose-blockquote:not-italic prose-code:break-words prose-code:rounded prose-code:bg-merino prose-code:px-1.5 prose-code:py-0.5 prose-code:font-normal prose-code:before:hidden prose-code:after:hidden [&_p]:before:hidden [&_p]:after:hidden"
                     >
-                        {!! preg_replace('/\<h1(.*)\>(.*)\<\/h1\>/', '', str(\App\Support\Markdown::parse($article->content))->sanitizeHtml()) !!}
+                        {!! \App\Support\Markdown::parse($article->content) !!}
                     </div>
                 </div>
             </div>

--- a/resources/views/plugins/view-plugin.blade.php
+++ b/resources/views/plugins/view-plugin.blade.php
@@ -343,7 +343,13 @@
                         <div
                             class="prose selection:bg-stone-500/30 prose-a:break-words prose-blockquote:not-italic prose-code:break-words prose-code:rounded prose-code:bg-merino prose-code:px-1.5 prose-code:py-0.5 prose-code:font-normal prose-code:before:hidden prose-code:after:hidden [&_p]:before:hidden [&_p]:after:hidden"
                         >
-                            {!! preg_replace('/\<h1(.*)\>(.*)\<\/h1\>/', '', str(\App\Support\Markdown::parse($docs))->sanitizeHtml()) !!}
+                            {!!
+                                \App\Support\Markdown::parse($docs)->absoluteImageUrls(
+                                    baseUrl: str($plugin->getDocUrl(request()->query('v')))
+                                        ->lower()
+                                        ->before('readme.md'),
+                                )
+                            !!}
                         </div>
                     </div>
                 @endif


### PR DESCRIPTION
This PR introduces functionality to automatically convert relative image URLs to absolute ones in plugin documentation and fixes existing issues with plugins that have already been merged with relative image URLs or got updated.

### Background
Currently, we require plugin authors to manually convert relative URLs to absolute ones. This process is cumbersome and error-prone. Moreover, even if authors comply, future updates to the README may inadvertently reintroduce relative URLs.

#### Implementation Details
Reworking the Markdown Class:
The Markdown class has been modified to accept the plugin documentation URL. This allows the system to resolve and convert image URLs based on the correct branch, ensuring accuracy and consistency.

#### Foundation for Future Enhancements:
This update lays the groundwork for additional replacements, such as converting video links into corresponding HTML tags. This functionality will be implemented in a future PR if this one is accepted.

By automating this process, we improve reliability and reduce the burden on plugin authors.