### PR TITLE
feat: add video conversion to HTML in Markdown parser

### DIFF
--- a/resources/views/plugins/view-plugin.blade.php
+++ b/resources/views/plugins/view-plugin.blade.php
@@ -344,11 +344,13 @@
                             class="prose selection:bg-stone-500/30 prose-a:break-words prose-blockquote:not-italic prose-code:break-words prose-code:rounded prose-code:bg-merino prose-code:px-1.5 prose-code:py-0.5 prose-code:font-normal prose-code:before:hidden prose-code:after:hidden [&_p]:before:hidden [&_p]:after:hidden"
                         >
                             {!!
-                                \App\Support\Markdown::parse($docs)->absoluteImageUrls(
-                                    baseUrl: str($plugin->getDocUrl(request()->query('v')))
-                                        ->lower()
-                                        ->before('readme.md'),
-                                )
+                                \App\Support\Markdown::parse($docs)
+                                    ->convertVideoToHtml()
+                                    ->absoluteImageUrls(
+                                        baseUrl: str($plugin->getDocUrl(request()->query('v')))
+                                            ->lower()
+                                            ->before('readme.md'),
+                                    )
                             !!}
                         </div>
                     </div>


### PR DESCRIPTION
This PR updates the markdown parsing to automatically turn specific URLs into `<video>` tags while ensuring there are no duplicates.

### What’s New:
#### Convert URLs to `<video>`:

- Targets URLs like https://github.com/user-attachments/assets/....
- Replaces unique URLs with a `<video>` tag containing the proper attributes.
- Clean Up Duplicates:
    - If the same URL shows up multiple times, it only keeps the first conversion and removes the rest.