### PR TITLE
feat: add draft status for plugins

### DIFF
--- a/app/Actions/GetPluginsListData.php
+++ b/app/Actions/GetPluginsListData.php
@@ -33,6 +33,9 @@ class GetPluginsListData
                         $plugins,
                         fn (EloquentBuilder $query) => $query->whereKey($plugins),
                     )
+                    ->where(
+                        fn (EloquentBuilder $query) => $query->whereNull('is_draft')->orWhere('is_draft', false)
+                    )
                     ->orderByDesc('publish_date')
                     ->with(['author'])
                     ->get()

--- a/app/Actions/GetPluginsListData.php
+++ b/app/Actions/GetPluginsListData.php
@@ -28,16 +28,13 @@ class GetPluginsListData
                     ->get()
                     ->pluck('count', 'starrable_id');
 
-                return Plugin::query()
+                return Plugin::with(['author'])
+                    ->draft(false)
                     ->when(
                         $plugins,
                         fn (EloquentBuilder $query) => $query->whereKey($plugins),
                     )
-                    ->where(
-                        fn (EloquentBuilder $query) => $query->whereNull('is_draft')->orWhere('is_draft', false)
-                    )
                     ->orderByDesc('publish_date')
-                    ->with(['author'])
                     ->get()
                     ->map(fn (Plugin $plugin): array => [
                         ...$plugin->getDataArray(),

--- a/app/Http/Controllers/Api/PluginController.php
+++ b/app/Http/Controllers/Api/PluginController.php
@@ -4,12 +4,19 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Models\Plugin;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
 
 class PluginController extends Controller
 {
-    public function index()
+    public function index(Request $request)
     {
-        return Plugin::paginate();
+        return Plugin::query()
+            ->when(
+                $request->boolean('draft'),
+                fn (Builder $query, bool $condition) => $query->draft($condition)
+            )
+            ->paginate();
     }
 
     public function show(Plugin $plugin)

--- a/app/Models/Plugin.php
+++ b/app/Models/Plugin.php
@@ -47,9 +47,9 @@ class Plugin extends Model implements Starrable
         $table->boolean('has_dark_theme')->default(false);
         $table->boolean('has_translations')->default(false);
         $table->string('image')->nullable();
+        $table->boolean('is_draft')->nullable()->default(false);
         $table->boolean('is_lemon_squeezy_embedded')->nullable()->default(false);
         $table->boolean('is_presale')->nullable()->default(false);
-        $table->boolean('is_draft')->nullable()->default(false);
         $table->string('name');
         $table->string('price')->nullable();
         $table->string('slug');

--- a/app/Models/Plugin.php
+++ b/app/Models/Plugin.php
@@ -27,6 +27,7 @@ class Plugin extends Model implements Starrable
         'has_translations' => 'boolean',
         'is_lemon_squeezy_embedded' => 'boolean',
         'is_presale' => 'boolean',
+        'is_draft' => 'boolean',
         'versions' => 'array',
         'publish_date' => 'date',
         'docs_urls' => 'array',
@@ -48,6 +49,7 @@ class Plugin extends Model implements Starrable
         $table->string('image')->nullable();
         $table->boolean('is_lemon_squeezy_embedded')->nullable()->default(false);
         $table->boolean('is_presale')->nullable()->default(false);
+        $table->boolean('is_draft')->nullable()->default(false);
         $table->string('name');
         $table->string('price')->nullable();
         $table->string('slug');
@@ -104,6 +106,11 @@ class Plugin extends Model implements Starrable
     public function isFree(): bool
     {
         return blank($this->price) && blank($this->anystack_id);
+    }
+
+    public function isDraft(): bool
+    {
+        return (bool) $this->is_draft;
     }
 
     public function getCheckoutUrl(): ?string

--- a/app/Models/Plugin.php
+++ b/app/Models/Plugin.php
@@ -69,6 +69,15 @@ class Plugin extends Model implements Starrable
         return $this->morphMany(Star::class, 'starrable');
     }
 
+    public function scopeDraft(Builder $query, bool $condition = true): Builder
+    {
+        if (! $condition) {
+            return $query->whereNull('is_draft')->orWhere('is_draft', false);
+        }
+
+        return $query->where('is_draft', true);
+    }
+
     public function getDocUrl(string $version = null): ?string
     {
         if (filled($this->docs_url)) {

--- a/resources/views/plugins/view-plugin.blade.php
+++ b/resources/views/plugins/view-plugin.blade.php
@@ -545,7 +545,7 @@
                     </div>
                 </div>
 
-                @if (count($otherPlugins = $plugin->author->plugins()->where('slug', '!=', $plugin->slug)->inRandomOrder()->limit(3)->get()))
+                @if (count($otherPlugins = $plugin->author->plugins()->draft(false)->where('slug', '!=', $plugin->slug)->inRandomOrder()->limit(3)->get()))
                     {{-- More From This Author --}}
                     <div>
                         <div class="text-lg font-extrabold">


### PR DESCRIPTION
This PR adds an `is_draft` column to the plugins table. Plugins marked as drafts will no longer appear in the plugin listing on the website. This ensures only non-draft plugins are publicly visible.