### PR TITLE
Wrap article title in an h1 instead of div

### DIFF
--- a/resources/views/articles/view-article.blade.php
+++ b/resources/views/articles/view-article.blade.php
@@ -72,9 +72,9 @@
 
                 {{-- Title --}}
                 <div class="pt-5">
-                    <div class="text-3xl font-extrabold">
+                    <h1 class="text-3xl font-extrabold">
                         {{ $article->title }}
-                    </div>
+                    </h1>
                 </div>
 
                 <div class="pt-2">


### PR DESCRIPTION
This PR replaces the `<div>` tag surrounding the article title on the article view page with an `<h1>` tag for SEO purposes.

TL;DR from the discussion in Discord, most of our articles have a highest heading size of `<h2>`, which means we were never using the top-most heading tier in our HTML.

Resolves #646 