### PR TITLE
Only force SSL scheme when in production

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -49,7 +49,9 @@ class AppServiceProvider extends ServiceProvider
             'plugin' => Plugin::class,
         ]);
 
-        URL::forceScheme('https');
+        if ($this->app->environment('production')) {
+            URL::forceScheme('https');
+        }
 
         RateLimiter::for('vpn_api', function (CheckIfIpIsVpn $job): Limit {
             if (


### PR DESCRIPTION
Unless I'm missing something, we just need SSL in production.

It alleviates the task to contribute when using `php artisan serve`.