### PR TITLE
fixed the styles of the multi language filter button

### DIFF
--- a/resources/views/components/plugins/list.blade.php
+++ b/resources/views/components/plugins/list.blade.php
@@ -402,7 +402,7 @@
                 class="text-sm transition duration-300"
                 :class="{
                     'text-salmon': features.translations,
-                    'opacity-70 text-dolphin group-hover/dark-mode-toggle:opacity-100': ! features.translations,
+                    'opacity-70 text-dolphin group-hover/multi-language-toggle:opacity-100': ! features.translations,
                 }"
             >
                 Multi language


### PR DESCRIPTION
The wrapper div of the multi language filter button have the class "group-hover/multi-language-toggle:opacity-100", but the div which holds the actual text it self have the class "group-hover/dark-mode-toggle:opacity-100".

Which prevented it from having the hover effect of the text.

I fixed it by applying the correct class name, "multi-language-toggle" instead of "dark-mode-toggle".