### PR TITLE
fix screenshot container height

### DIFF
--- a/docs/src/components/AutoScreenshot.astro
+++ b/docs/src/components/AutoScreenshot.astro
@@ -11,7 +11,7 @@ const image = fs.readFileSync(new URL(
 const dimensions = probe.sync(image);
 ---
 
-<div style={`aspect-ratio: ${dimensions.width} / ${dimensions.height}`} class="rounded-xl mb-6 ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
+<div style={`aspect-ratio: ${dimensions.width} / ${dimensions.height}; max-height: ${dimensions.height};`} class="rounded-xl mb-6 ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
     <img
         src={`/docs/${version}/images/light/${name}.jpg`}
         alt={alt}


### PR DESCRIPTION
First, I'm have to confess I never used Astro before and this is not tested on my local, but it seems to straightfoward enough.

The cosmetic issue is with the aspect ratio set on image container, when on a large screen(4K, > lg) the screenshot is smaller than the container, leading to empty spaces
![image](https://github.com/user-attachments/assets/db476762-aa1f-49a0-8874-a248283f4883)

By setting a max-height / w-fit (test in browser inspect), the container will fit the image
![image](https://github.com/user-attachments/assets/f554f72f-b986-4428-878a-56ed42c3d046)


an alternative approach will be making the image w-full but that would enlarge everything, which would not be nice for smaller screenshots