### PR TITLE
Price Changed for Jitone AI Pro

### DIFF
--- a/content/plugins/jitendriya-tripathy-jitoneai-pro.md
+++ b/content/plugins/jitendriya-tripathy-jitoneai-pro.md
@@ -12,7 +12,7 @@ github_repository: jiten14/jitoneai-pro
 has_dark_theme: true
 has_translations: false
 is_presale: false
-price: $49.00
+price: $19.00
 versions: [3]
 publish_date: 2025-02-01
 ---


### PR DESCRIPTION
This pull request updates the **pricing** for the **Jitone AI Pro** plugin.

- **Previous Price:** $49 (one-time payment)  
- **New Price:** $19 (one-time payment)  

To make Jitone AI Pro more accessible to a wider audience and increase adoption, the price has been reduced while retaining **all features**, **lifetime updates**, and **unlimited site usage**.

Please review and merge.
