### PR TITLE
Update marcelweidum-expiration-notice to support v3 & v4 and has translations

### DIFF
--- a/content/plugins/marcelweidum-expiration-notice.md
+++ b/content/plugins/marcelweidum-expiration-notice.md
@@ -8,7 +8,7 @@ discord_url: https://discord.com/channels/883083792112300104/1385352172027510795
 docs_url: https://raw.githubusercontent.com/MarcelWeidum/filament-expiration-notice/refs/heads/main/README.md
 github_repository: MarcelWeidum/filament-expiration-notice
 has_dark_theme: true
-has_translations: false
-versions: [3]
+has_translations: true
+versions: [3,4]
 publish_date: 2025-06-19
 ---

--- a/content/plugins/marcelweidum-expiration-notice.md
+++ b/content/plugins/marcelweidum-expiration-notice.md
@@ -9,6 +9,6 @@ docs_url: https://raw.githubusercontent.com/MarcelWeidum/filament-expiration-not
 github_repository: MarcelWeidum/filament-expiration-notice
 has_dark_theme: true
 has_translations: true
-versions: [3,4]
+versions: [3, 4]
 publish_date: 2025-06-19
 ---


### PR DESCRIPTION
This pull request updates metadata for the `marcelweidum-expiration-notice` plugin. It includes changes to enable translations and expand version compatibility.

Metadata updates:

* [`content/plugins/marcelweidum-expiration-notice.md`](diffhunk://#diff-b427b587754b0a65df0dfa1d36137a2297c08162a2f5e5dc5d7ca4bf083862edL11-R12): Updated `has_translations` from `false` to `true`, indicating that translations are now supported.
* [`content/plugins/marcelweidum-expiration-notice.md`](diffhunk://#diff-b427b587754b0a65df0dfa1d36137a2297c08162a2f5e5dc5d7ca4bf083862edL11-R12): Expanded `versions` to include version `4` in addition to version `3`, reflecting broader compatibility.