### PR TITLE
Update `codewithdennis` plugin versions to include version 4

### DIFF
--- a/content/plugins/codewithdennis-advanced-components.md
+++ b/content/plugins/codewithdennis-advanced-components.md
@@ -10,6 +10,6 @@ github_repository: codewithdennis/filament-advanced-components
 docs_url: https://raw.githubusercontent.com/CodeWithDennis/filament-advanced-components-documentation/main/README.md
 has_dark_theme: true
 has_translations: false
-versions: [3,4]
+versions: [3, 4]
 publish_date: 2025-01-05
 ---

--- a/content/plugins/codewithdennis-advanced-components.md
+++ b/content/plugins/codewithdennis-advanced-components.md
@@ -10,6 +10,6 @@ github_repository: codewithdennis/filament-advanced-components
 docs_url: https://raw.githubusercontent.com/CodeWithDennis/filament-advanced-components-documentation/main/README.md
 has_dark_theme: true
 has_translations: false
-versions: [3]
+versions: [3,4]
 publish_date: 2025-01-05
 ---

--- a/content/plugins/codewithdennis-simple-alert.md
+++ b/content/plugins/codewithdennis-simple-alert.md
@@ -9,6 +9,6 @@ docs_url: https://raw.githubusercontent.com/CodeWithDennis/filament-simple-alert
 github_repository: codewithdennis/filament-simple-alert
 has_dark_theme: true
 has_translations: false
-versions: [3,4]
+versions: [3, 4]
 publish_date: 2024-07-01
 ---

--- a/content/plugins/codewithdennis-simple-alert.md
+++ b/content/plugins/codewithdennis-simple-alert.md
@@ -9,6 +9,6 @@ docs_url: https://raw.githubusercontent.com/CodeWithDennis/filament-simple-alert
 github_repository: codewithdennis/filament-simple-alert
 has_dark_theme: true
 has_translations: false
-versions: [3]
+versions: [3,4]
 publish_date: 2024-07-01
 ---


### PR DESCRIPTION
This pull request updates the supported versions for two plugins in the `content/plugins` directory to include version 4.

Version updates:

* [`content/plugins/codewithdennis-advanced-components.md`](diffhunk://#diff-9b88821371adeece4a017d6ad016e8a5ee6d7c8608b60d54ea301d2143bd15b0L13-R13): Updated the `versions` field to include version 4 alongside version 3.
* [`content/plugins/codewithdennis-simple-alert.md`](diffhunk://#diff-a222e1503cc6342224a3fa940e580dd9b4981e5fa875fa804d362a37d6517b0cL12-R12): Updated the `versions` field to include version 4 alongside version 3.