### PR TITLE
chore: indicate v4 support for swisnl-backgrounds

### DIFF
--- a/content/plugins/swisnl-backgrounds.md
+++ b/content/plugins/swisnl-backgrounds.md
@@ -9,6 +9,6 @@ docs_url: https://raw.githubusercontent.com/swisnl/filament-backgrounds/main/REA
 github_repository: swisnl/filament-backgrounds
 has_dark_theme: true
 has_translations: true
-versions: [3]
+versions: [3, 4]
 publish_date: 2023-11-29
 ---


### PR DESCRIPTION
I just released https://github.com/swisnl/filament-backgrounds/releases/tag/2.0.0 with Filament 4 support!