### PR TITLE
Plugins - Add Filament v4 support for Miguilim Auto Panel

### DIFF
--- a/content/plugins/miguilim-auto-panel.md
+++ b/content/plugins/miguilim-auto-panel.md
@@ -9,6 +9,6 @@ docs_url: https://raw.githubusercontent.com/miguilimzero/filament-auto-panel/mai
 github_repository: miguilimzero/filament-auto-panel
 has_dark_theme: true
 has_translations: true
-versions: [3]
+versions: [3, 4]
 publish_date: 2023-08-28
 ---


### PR DESCRIPTION
This PR just adds the version number to the array. The plugin works in the same way as the previous version, and the documentation stays the same.