### PR TITLE
defstudio Searchable Input v4 support

### DIFF
--- a/content/plugins/defstudio-searchable-input.md
+++ b/content/plugins/defstudio-searchable-input.md
@@ -5,10 +5,12 @@ author_slug: defstudio
 categories: [form-field, form-builder]
 description: A searchable autocomplete input form field.
 discord_url: https://discord.com/channels/883083792112300104/1367710460182532146
-docs_url: https://raw.githubusercontent.com/defstudio/filament-searchable-input/refs/heads/main/FILAMENT_README.md
+docs_urls:
+    v3: https://raw.githubusercontent.com/defstudio/filament-searchable-input/refs/heads/v1.x/FILAMENT_README.md
+    v4: https://raw.githubusercontent.com/defstudio/filament-searchable-input/refs/heads/main/FILAMENT_README.md
 github_repository: defstudio/filament-searchable-input
 has_dark_theme: true
 has_translations: false
-versions: [3]
+versions: [3,4]
 publish_date: 2025-05-02
 ---


### PR DESCRIPTION
This PR will update the defstudio/filament-searchable-input plugin page to highlight Filament v4 support