### PR TITLE
Add v4 support to Filament Rating

### DIFF
--- a/content/plugins/mokhosh-rating.md
+++ b/content/plugins/mokhosh-rating.md
@@ -9,6 +9,6 @@ docs_url: https://raw.githubusercontent.com/mokhosh/filament-rating/main/README.
 github_repository: mokhosh/filament-rating
 has_dark_theme: true
 has_translations: true
-versions: [3]
+versions: [3, 4]
 publish_date: 2024-03-20
 ---


### PR DESCRIPTION
https://github.com/mokhosh/filament-rating/releases/tag/v2.0.0 has added v4 support