### PR TITLE
fix(markdown): correctly rewrite relative src and srcset URLs to absolute

### DIFF
--- a/app/Support/Markdown.php
+++ b/app/Support/Markdown.php
@@ -114,9 +114,9 @@ class Markdown implements Htmlable, Stringable
     public function absoluteImageUrls(string $baseUrl): static
     {
         $this->content = preg_replace(
-            pattern: '/src=["\'](?!https?:\/\/)([^"\']+)["\'][^>]/i',
-            replacement: 'src="' . $baseUrl . '$1" ',
-            subject: $this->content
+            '/\b(src|srcset)\s*=\s*(["\'])(?!https?:\/\/|data:|\/\/)([^"\']+)\2/i',
+            '$1=$2' . $baseUrl . '$3$2',
+            $this->content
         );
 
         return $this;

--- a/app/Support/Markdown.php
+++ b/app/Support/Markdown.php
@@ -114,9 +114,9 @@ class Markdown implements Htmlable, Stringable
     public function absoluteImageUrls(string $baseUrl): static
     {
         $this->content = preg_replace(
-            '/\b(src|srcset)\s*=\s*(["\'])(?!https?:\/\/|data:|\/\/)([^"\']+)\2/i',
-            '$1=$2' . $baseUrl . '$3$2',
-            $this->content
+            pattern: '/\b(src|srcset)\s*=\s*(["\'])(?!https?:\/\/|data:|\/\/)([^"\']+)\2/i',
+            replacement: '$1=$2' . $baseUrl . '$3$2',
+            subject: $this->content
         );
 
         return $this;


### PR DESCRIPTION
This PR fixes the `absoluteImageUrls` method to properly convert relative `src` and `srcset` attributes into absolute URLs.

•	Updated regex to handle both src and srcset
•	Preserves original quotes
•	Ignores already absolute URLs (http(s), //, data:)