### PR TITLE
Enable translations for the Kirschbaum Commentions plugin

### DIFF
--- a/content/plugins/kirschbaum-commentions.md
+++ b/content/plugins/kirschbaum-commentions.md
@@ -8,7 +8,7 @@ discord_url: https://discord.com/channels/883083792112300104/1385339338027696138
 docs_url: https://raw.githubusercontent.com/kirschbaum-development/commentions/refs/heads/main/README.md
 github_repository: kirschbaum-development/commentions
 has_dark_theme: true
-has_translations: false
+has_translations: true
 versions: [3, 4]
 publish_date: 2025-06-19
 ---


### PR DESCRIPTION
This pull request makes a small configuration update to the `kirschbaum-commentions.md` plugin descriptor. The change enables translations support for the plugin.

* Set `has_translations` to `true` in `kirschbaum-commentions.md`, indicating that the plugin now supports translations.