### PR TITLE
Add version 4 to rickdbcn-email plugin

### DIFF
--- a/content/plugins/rickdbcn-email.md
+++ b/content/plugins/rickdbcn-email.md
@@ -9,6 +9,6 @@ docs_url: https://raw.githubusercontent.com/RickDBCN/filament-email/main/README.
 github_repository: rickdbcn/filament-email
 has_dark_theme: true
 has_translations: true
-versions: [3]
+versions: [3, 4]
 publish_date: 2023-08-08
 ---


### PR DESCRIPTION
Plugin is now compatible with v4.