### PR TITLE
Update queueable-bulk-actions to include v4 support

### DIFF
--- a/content/plugins/eddie-rusinskas-queueable-bulk-actions.md
+++ b/content/plugins/eddie-rusinskas-queueable-bulk-actions.md
@@ -9,6 +9,6 @@ docs_url: https://raw.githubusercontent.com/bytexr/filament-queueable-bulk-actio
 github_repository: bytexr/filament-queueable-bulk-actions
 has_dark_theme: true
 has_translations: true
-versions: [3,4]
+versions: [3, 4]
 publish_date: 2024-04-24
 ---


### PR DESCRIPTION
Update queueable-bulk-actions to include v4 support