### PR TITLE
Add platform extensions to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -89,6 +89,10 @@
         "allow-plugins": {
             "composer/package-versions-deprecated": true,
             "php-http/discovery": true
+        },
+        "platform": {
+            "ext-pcntl": "7.1",
+            "ext-posix": "7.1"
         }
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Added platform requirements for ext-pcntl and ext-posix. Fix composer install in Windows OS.