### PR TITLE
Add Indonesia Weather Widget plugin

### DIFF
--- a/content/plugins/rizal-indonesia-weather-widget.md
+++ b/content/plugins/rizal-indonesia-weather-widget.md
@@ -1,0 +1,14 @@
+---
+name: Indonesia Weather Widget
+slug: rizal-indonesia-weather-widget
+author_slug: rizal
+categories: [widget]
+description: A Filament widget that displays real-time weather information from BMKG (Badan Meteorologi, Klimatologi, dan Geofisika) API for Indonesian regions.
+discord_url: 
+docs_url: https://raw.githubusercontent.com/fadhriza/indonesia-weather-plugins/main/README.md
+github_repository: fadhriza/indonesia-weather-plugins
+has_dark_theme: true
+has_translations: true
+versions: [1]
+publish_date: 2024-12-19
+---


### PR DESCRIPTION
This pull request adds a new plugin entry for the Indonesia Weather Widget to the documentation. The entry provides metadata and resource links for a Filament widget that displays real-time weather information for Indonesian regions.

New plugin documentation:

* Added `rizal-indonesia-weather-widget.md` with details about the Indonesia Weather Widget, including description, author, categories, documentation link, GitHub repository, and feature flags.