### PR TITLE
Add platform extensions to composer.lock

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -11850,5 +11850,9 @@
         "php": "^8.1"
     },
     "platform-dev": [],
+    "platform-overrides": {
+        "ext-pcntl": "7.1",
+        "ext-posix": "7.1"
+    },
     "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
Added platform requirements for ext-pcntl and ext-posix. Fix composer install in Windows OS.

This PR related #1116.

I ended up forgetting to change the composer.lock file in PR #1116 as well.