### PR TITLE
Add Filament v4 support to Collapsible Sub-Nav plugin

### DIFF
--- a/content/plugins/isach-collapsible-subnav.md
+++ b/content/plugins/isach-collapsible-subnav.md
@@ -8,6 +8,6 @@ docs_url: https://raw.githubusercontent.com/Emuniq/filament-collapsible-subnav/m
 github_repository: Emuniq/filament-collapsible-subnav
 has_dark_theme: true
 has_translations: false
-versions: [3]
+versions: [3, 4]
 publish_date: 2025-12-26
 ---


### PR DESCRIPTION
The plugin is compatible with both Filament v3 and v4.
